### PR TITLE
Fix README to reference UI folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ ReForm is an AI-powered platform that transforms raw content (documents, slides,
 ## 🧱 Project Structure
 
 ```
-/content-reform-frontend    # Next.js + Tailwind frontend
+/content-reform-ui    # Next.js + Tailwind frontend
 /content-reform-backend     # Express.js + OpenAI backend
 ```
 
@@ -40,10 +40,10 @@ cd reform
 
 ---
 
-### 2. Frontend Setup (`/content-reform-frontend`)
+### 2. Frontend Setup (`/content-reform-ui`)
 
 ```bash
-cd content-reform-frontend
+cd content-reform-ui
 npm install
 npm run dev
 ```


### PR DESCRIPTION
## Summary
- update README project structure to use `content-reform-ui`
- update frontend setup instructions for the new folder name

## Testing
- `npm test` in `content-reform-backend` *(fails: Missing script)*
- `npm test` in `content-reform-ui` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68496eab0830833193b13406dfb7fa51